### PR TITLE
D-36960 Fix class cast exception in delete config workflows

### DIFF
--- a/DigitalAIOfficial/Workflows/ArgoCD/Workflow_ArgoCD delete live deployment configuration.yaml
+++ b/DigitalAIOfficial/Workflows/ArgoCD/Workflow_ArgoCD delete live deployment configuration.yaml
@@ -36,17 +36,16 @@ spec:
               liveDeploymentConfigs = statusWebhookEventSource.getProperty("liveDeploymentConfigs")
               
               configToDelete = None
-              liveDeploymentConfigs = set()
               for config in statusWebhookEventSource.getProperty("liveDeploymentConfigs"):
                 if config.id == "${liveDeploymentConfigurationId}":
-                    configToDelete = config.id
-                else:
-                    liveDeploymentConfigs.add(config)
+                  configToDelete = config
+                  break
               
               if configToDelete:
+                liveDeploymentConfigs.remove(configToDelete)
                 statusWebhookEventSource.setProperty("liveDeploymentConfigs", liveDeploymentConfigs)
                 configurationApi.updateConfiguration("${statusWebhookEventSourceId}", statusWebhookEventSource)
-                configurationApi.deleteConfiguration(configToDelete)
+                configurationApi.deleteConfiguration(configToDelete.id)
           - name: Patch ArgoCD applications
             type: xlrelease.ScriptTask
             description: |-

--- a/DigitalAIOfficial/Workflows/Digital.ai Deploy/Workflow_Deploy delete live deployment configuration.yaml
+++ b/DigitalAIOfficial/Workflows/Digital.ai Deploy/Workflow_Deploy delete live deployment configuration.yaml
@@ -36,17 +36,16 @@ spec:
               liveDeploymentConfigs = statusWebhookEventSource.getProperty("liveDeploymentConfigs")
               
               configToDelete = None
-              liveDeploymentConfigs = set()
               for config in statusWebhookEventSource.getProperty("liveDeploymentConfigs"):
                 if config.id == "${liveDeploymentConfigurationId}":
-                    configToDelete = config.id
-                else:
-                    liveDeploymentConfigs.add(config)
+                 configToDelete = config
+                 break
               
               if configToDelete:
+                liveDeploymentConfigs.remove(configToDelete)
                 statusWebhookEventSource.setProperty("liveDeploymentConfigs", liveDeploymentConfigs)
                 configurationApi.updateConfiguration("${statusWebhookEventSourceId}", statusWebhookEventSource)
-                configurationApi.deleteConfiguration(configToDelete)
+                configurationApi.deleteConfiguration(configToDelete.id)
           - name: Autoconfigure deployment provider
             type: xlrelease.ScriptTask
             script: |-


### PR DESCRIPTION
- Summary: This pull request addresses class cast exception In "Delete ArgoCD/Deploy live deployment configuration" workflows

**Version information**
- [ ] Tested against target systems and versions: Release 24.3.x
- [ ] Tested with Digital.AI Release version: Release 24.3.x

**Review**

- [ ] If adding a new workflow, update the `Releasefile.yaml` for proper Digital.ai Release import.
- [ ] Avoid using community plugins.
- [ ] Do not use global or folder variables.
- [ ] Confirm that variables follow the correct naming convention (camel case or snake case) and have appropriate labels and descriptions.
- [ ] Workflows should have accurate titles and descriptions.
- [ ] Verify that all phases and tasks have correct titles and descriptions.
- [ ] Ensure the change fulfills and explains the business requirements properly.
- [ ] Place the workflow in the correct folder based on its category, and ensure that proper documentation accompanies it.

**QE**

- [ ] Confirm that the changes can be successfully imported into Digital.ai Release without any breaking issues.
- [ ] Generate a workflow execution from the newly added or updated workflow and verify that there are no failures.

**PR Merge Activity**

- [ ] Squash and merge the PR.
- [ ] After the PR is merged, make sure to push the appropriate tags on the target branch to reflect the changes in customer installations.
