### PR TITLE
S-114170 Remove default execution folder for Deployment Server related workflows

### DIFF
--- a/DigitalAIOfficial/Workflows/ArgoCD/Workflow_ArgoCD setup application.yaml
+++ b/DigitalAIOfficial/Workflows/ArgoCD/Workflow_ArgoCD setup application.yaml
@@ -596,4 +596,3 @@ spec:
       type: xlrelease.TemplateLogo
       contentType: image/png
       file: !file "template-logo/c9e27d5b1d5ed9738d58781439732acacd6b482d/argocd.svg"
-    defaultTargetFolder: Digital.ai - Official/Workflow Executions

--- a/DigitalAIOfficial/Workflows/ArgoCD/Workflow_ArgoCD setup deployment server.yaml
+++ b/DigitalAIOfficial/Workflows/ArgoCD/Workflow_ArgoCD setup deployment server.yaml
@@ -108,4 +108,3 @@ spec:
       type: xlrelease.TemplateLogo
       contentType: image/svg+xml
       file: !file "template-logo/c9e27d5b1d5ed9738d58781439732acacd6b482d/argocd.svg"
-    defaultTargetFolder: Digital.ai - Official/Workflow Executions

--- a/DigitalAIOfficial/Workflows/ArgoCD/Workflow_ArgoCD setup live deployment configuration.yaml
+++ b/DigitalAIOfficial/Workflows/ArgoCD/Workflow_ArgoCD setup live deployment configuration.yaml
@@ -134,4 +134,3 @@ spec:
     type: xlrelease.TemplateLogo
     contentType: image/png
     file: !file "template-logo/c9e27d5b1d5ed9738d58781439732acacd6b482d/argocd.svg"
-  defaultTargetFolder: Digital.ai - Official/Workflow Executions

--- a/DigitalAIOfficial/Workflows/Digital.ai Deploy/Workflow_AWS Lambda setup function with Digital.ai Deploy.yaml
+++ b/DigitalAIOfficial/Workflows/Digital.ai Deploy/Workflow_AWS Lambda setup function with Digital.ai Deploy.yaml
@@ -329,4 +329,3 @@ spec:
     type: xlrelease.TemplateLogo
     contentType: image/svg+xml
     file: !file "template-logo/8a6a02deb543807bb34b22aef762b92e7a70adb2/deploy.svg"
-  defaultTargetFolder: Digital.ai - Official/Workflow Executions

--- a/DigitalAIOfficial/Workflows/Digital.ai Deploy/Workflow_Azure setup application with Digital.ai Deploy.yaml
+++ b/DigitalAIOfficial/Workflows/Digital.ai Deploy/Workflow_Azure setup application with Digital.ai Deploy.yaml
@@ -299,4 +299,3 @@ spec:
     type: xlrelease.TemplateLogo
     contentType: image/svg+xml
     file: !file "template-logo/97662a62108c2b1e1875c8e18f6d1c72a013d33c/deploy.svg"
-  defaultTargetFolder: Digital.ai - Official/Workflow Executions

--- a/DigitalAIOfficial/Workflows/Digital.ai Deploy/Workflow_Deploy setup deployment server.yaml
+++ b/DigitalAIOfficial/Workflows/Digital.ai Deploy/Workflow_Deploy setup deployment server.yaml
@@ -104,4 +104,3 @@ spec:
       type: xlrelease.TemplateLogo
       contentType: image/svg+xml
       file: !file "template-logo/97662a62108c2b1e1875c8e18f6d1c72a013d33c/deploy.svg"
-    defaultTargetFolder: Digital.ai - Official/Workflow Executions

--- a/DigitalAIOfficial/Workflows/Digital.ai Deploy/Workflow_Deploy setup live deployment configuration.yaml
+++ b/DigitalAIOfficial/Workflows/Digital.ai Deploy/Workflow_Deploy setup live deployment configuration.yaml
@@ -158,4 +158,3 @@ spec:
     type: xlrelease.TemplateLogo
     contentType: image/svg+xml
     file: !file "template-logo/97662a62108c2b1e1875c8e18f6d1c72a013d33c/deploy.svg"
-  defaultTargetFolder: Digital.ai - Official/Workflow Executions

--- a/DigitalAIOfficial/Workflows/Digital.ai Deploy/Workflow_GCP setup application with Digital.ai Deploy.yaml
+++ b/DigitalAIOfficial/Workflows/Digital.ai Deploy/Workflow_GCP setup application with Digital.ai Deploy.yaml
@@ -320,4 +320,3 @@ spec:
     type: xlrelease.TemplateLogo
     contentType: image/svg+xml
     file: !file "template-logo/1acf43f120046fcbeca6ce60329683dc10bb741d/deploy.svg"
-  defaultTargetFolder: Digital.ai - Official/Workflow Executions

--- a/DigitalAIOfficial/Workflows/Digital.ai Deploy/Workflow_Helm application setup with Digital.ai Deploy.yaml
+++ b/DigitalAIOfficial/Workflows/Digital.ai Deploy/Workflow_Helm application setup with Digital.ai Deploy.yaml
@@ -553,4 +553,3 @@ spec:
     type: xlrelease.TemplateLogo
     contentType: image/svg+xml
     file: !file "template-logo/1336d33f613cec76ae8d02f10c5e6f34da6ac0a7/helm.svg"
-  defaultTargetFolder: Digital.ai - Official/Workflow Executions

--- a/DigitalAIOfficial/Workflows/Digital.ai Deploy/Workflow_Tomcat DataSource setup with Digital.ai Deploy.yaml
+++ b/DigitalAIOfficial/Workflows/Digital.ai Deploy/Workflow_Tomcat DataSource setup with Digital.ai Deploy.yaml
@@ -429,4 +429,3 @@ spec:
     type: xlrelease.TemplateLogo
     contentType: image/svg+xml
     file: !file "template-logo/9a6971f732677b76071b3d996d2cbb1d77fb617a/deploy.svg"
-  defaultTargetFolder: Digital.ai - Official/Workflow Executions

--- a/DigitalAIOfficial/Workflows/Digital.ai Deploy/Workflow_Websphere JaasAlias setup with Digital.ai Deploy.yaml
+++ b/DigitalAIOfficial/Workflows/Digital.ai Deploy/Workflow_Websphere JaasAlias setup with Digital.ai Deploy.yaml
@@ -427,4 +427,3 @@ spec:
     type: xlrelease.TemplateLogo
     contentType: image/svg+xml
     file: !file "template-logo/9dda4235a32e0a48f98fd815771690a722aeb812/deploy.svg"
-  defaultTargetFolder: Digital.ai - Official/Workflow Executions


### PR DESCRIPTION
- Summary: This pull request removes default execution folder for workflows that we want to run on current folder we are running it from, e.g. all of the creational Deployment Server workflows or those that are onboarding of new application started from Live Deployment pages.

**Version information**
- [ ] Tested against target systems and versions: _FILL IN TARGET SYSTEMS AND TARGET SYSTEM VERSIONS HERE_
- [ ] Tested with Digital.AI Release version: _FILL IN DIGITAL.AI RELEASE VERSION AND PLUGIN VERSIONS HERE_

**Review**

- [ ] If adding a new workflow, update the `Releasefile.yaml` for proper Digital.ai Release import.
- [ ] Avoid using community plugins.
- [ ] Do not use global or folder variables.
- [ ] Confirm that variables follow the correct naming convention (camel case or snake case) and have appropriate labels and descriptions.
- [ ] Workflows should have accurate titles and descriptions.
- [ ] Verify that all phases and tasks have correct titles and descriptions.
- [ ] Ensure the change fulfills and explains the business requirements properly.
- [ ] Place the workflow in the correct folder based on its category, and ensure that proper documentation accompanies it.

**QE**

- [ ] Confirm that the changes can be successfully imported into Digital.ai Release without any breaking issues.
- [ ] Generate a workflow execution from the newly added or updated workflow and verify that there are no failures.

**PR Merge Activity**

- [ ] Squash and merge the PR.
- [ ] After the PR is merged, make sure to push the appropriate tags on the target branch to reflect the changes in customer installations.
